### PR TITLE
Bugfix for scala starter notebook.

### DIFF
--- a/notebooks/examples/scala/QuickstartNotebook.scala
+++ b/notebooks/examples/scala/QuickstartNotebook.scala
@@ -179,7 +179,7 @@ display(tripsWithIndex)
 val neighbourhoodsWithIndex = neighbourhoods
    // We break down the original geometry in multiple smoller mosaic chips, each with its
    // own index
-   .withColumn("mosaic_index", mosaic_explode(col("geometry"), lit(optimal_resolution)))
+   .withColumn("mosaic_index", mosaic_explode(col("geometry"), lit(optimalResolution)))
    // We don't need the original geometry any more, since we have broken it down into
    // Smaller mosaic chips.
    .drop("json_geometry", "geometry")


### PR DESCRIPTION
Fixes incorrect reference to `optimal_resolution` in scala quickstart notebook