### PR TITLE
Update build logic

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -1,12 +1,11 @@
-name: build everything
+name: build main
 on:
   push:
-    branches:
-      - "!R/*"
-      - "!r/*"
-      - "!python/*"
-      - "!scala/*"
-      - "**"
+    branches-ignore:
+      - "R/*"
+      - "r/*"
+      - "python/*"
+      - "scala/*"
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
the build_main workflow was running on everything, I think the push: branches part of the regex operates as OR rather than AND, and the catch-all ** was causing it to run even on a "python/*" branch. Also updated the name to refflect the workflow file name