### PR TITLE
export to_json

### DIFF
--- a/R/sparklyr-mosaic/sparkFunctions.R
+++ b/R/sparklyr-mosaic/sparkFunctions.R
@@ -1,4 +1,17 @@
 # sparklyr doesnt have this, easier to bring bring it across than use a udf
+
+#' @description provides an interface to Spark's to_json() function.
+#' See \url{https://databrickslabs.github.io/mosaic/} for full documentation
+#' @param sc sparkContext
+#' @name to_json
+#' @rdname to_json
+#' @return None
+#' @export to_json
+#' @examples
+#' \dontrun{
+#' sparklyr_data_frame %>%
+#' mutate(spark_json_data = to_json(json_as_string))
+#' }
 to_json <- function(sc){
   sparklyr::invoke_static("org.apache.spark.sql.functions", "to_json", spark_session(sc))
 }


### PR DESCRIPTION
This adds the to_json function, which is missing natively in sparklyr. The code was present in previous sparklyrMosaic releases but was not exported. This fixes that 