### PR TITLE
Feature/grid_tocenterwkb

### DIFF
--- a/python/mosaic/api/functions.py
+++ b/python/mosaic/api/functions.py
@@ -51,6 +51,7 @@ __all__ = [
     "grid_polyfill",
     "grid_tessellate",
     "grid_tessellateexplode",
+    "grid_centeraswkb",
 
     "point_index_geom",
     "point_index_lonlat",
@@ -1037,3 +1038,21 @@ def mosaicfill(
         pyspark_to_java_column(resolution),
         pyspark_to_java_column(keep_core_geometries),
     )
+
+def grid_centeraswkb(geom: ColumnOrName) -> Column:
+    """
+    Return the centroid of an index by providing the index id.
+
+    index_id : Column
+    The grid cell ID
+
+    Returns
+    -------
+    Column
+    A geometry in WKB format
+
+    """
+    return config.mosaic_context.invoke_function(
+        "grid_centeraswkb", pyspark_to_java_column(geom)
+    )
+

--- a/src/main/scala/com/databricks/labs/mosaic/core/index/BNGIndexSystem.scala
+++ b/src/main/scala/com/databricks/labs/mosaic/core/index/BNGIndexSystem.scala
@@ -534,4 +534,13 @@ object BNGIndexSystem extends IndexSystem with Serializable {
 
     override def getResolutionStr(resolution: Int): String = resolutionMap.find(_._2 == resolution).map(_._1).getOrElse("")
 
+    override def GridCenterAsWKB(index: Long, geometryAPI: GeometryAPI): MosaicGeometry = {
+        val digits = indexDigits(index)
+        val resolution = getResolution(digits)
+        val edgeSize = getEdgeSize(resolution)
+        val x = getX(digits, edgeSize)
+        val y = getY(digits, edgeSize)
+        geometryAPI.fromCoords(Seq(x + edgeSize / 2, y + edgeSize / 2))
+    }
+
 }

--- a/src/main/scala/com/databricks/labs/mosaic/core/index/H3IndexSystem.scala
+++ b/src/main/scala/com/databricks/labs/mosaic/core/index/H3IndexSystem.scala
@@ -208,4 +208,18 @@ object H3IndexSystem extends IndexSystem with Serializable {
 
     override def getResolutionStr(resolution: Int): String = resolution.toString
 
+    /**
+     * Get the centroid of an index by providing index id.
+     *
+     * @param index
+     * Id of the index whose centroid geometry should be returned.
+     * @return
+     * An instance of [[MosaicGeometry]] corresponding to the centroid of the
+     * index.
+     */
+    override def GridCenterAsWKB(index: Long, geometryAPI: GeometryAPI): MosaicGeometry = {
+        val p = h3.h3ToGeo(index)
+        geometryAPI.fromGeoCoord(Coordinates(p.lat, p.lng))
+    }
+
 }

--- a/src/main/scala/com/databricks/labs/mosaic/core/index/IndexSystem.scala
+++ b/src/main/scala/com/databricks/labs/mosaic/core/index/IndexSystem.scala
@@ -193,4 +193,17 @@ trait IndexSystem extends Serializable {
       */
     def pointToIndex(lon: Double, lat: Double, resolution: Int): Long
 
+    /**
+     * Get the centroid of an index ID.
+     *
+     * @param index
+     * Id of the index whose centroid geometry should be returned.
+     * @return
+     * An instance of [[MosaicGeometry]] corresponding to the centroid of the
+     * index.
+     */
+    def GridCenterAsWKB(index: Long, geometryAPI: GeometryAPI): MosaicGeometry
+
 }
+
+

--- a/src/main/scala/com/databricks/labs/mosaic/expressions/index/GridCenterAsWKB.scala
+++ b/src/main/scala/com/databricks/labs/mosaic/expressions/index/GridCenterAsWKB.scala
@@ -1,0 +1,83 @@
+package com.databricks.labs.mosaic.expressions.index
+
+import com.databricks.labs.mosaic.core.geometry.api.GeometryAPI
+import com.databricks.labs.mosaic.core.index.IndexSystemID
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionDescription, ExpressionInfo, NullIntolerant, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types._
+
+@ExpressionDescription(
+    usage = "_FUNC_(indexID, indexSystem) - Returns the geometry representing the centroid of the index.",
+    examples = """
+    Examples:
+      > SELECT _FUNC_(a, 'H3');
+      0001100100100.....001010 // WKB
+  """,
+    since = "1.0"
+)
+case class GridCenterAsWKB(indexID: Expression, indexSystemName: String, geometryAPIName: String)
+    extends UnaryExpression
+        with NullIntolerant
+        with CodegenFallback {
+
+    /** Expression output DataType. */
+    // Return WKB, if other type is required call ConvertTO
+    override def dataType: DataType = BinaryType
+
+    override def toString: String = s"grid_centeraswkb($indexID)"
+
+    /** Overridden to ensure [[Expression.sql]] is properly formatted. */
+    override def prettyName: String = "grid_centeraswkb"
+
+    /**
+     * Returns the geometry representing the centroid of the index.
+     *
+     * @param input1
+     *   Any instance containing the ID of the index.
+     * @return
+     *   WKB representation of the centroid of the index provided.
+     */
+    override def nullSafeEval(input1: Any): Any = {
+        val indexSystem = IndexSystemID.getIndexSystem(IndexSystemID(indexSystemName))
+        val geometryAPI = GeometryAPI(geometryAPIName)
+        val indexCentroid = indexSystem.GridCenterAsWKB(input1.asInstanceOf[Long], geometryAPI)
+        indexCentroid.toWKB
+    }
+
+    override def makeCopy(newArgs: Array[AnyRef]): Expression = {
+        val arg1 = newArgs.head.asInstanceOf[Expression]
+        val res = GridCenterAsWKB(indexID, indexSystemName, geometryAPIName)
+        res.copyTagsFrom(this)
+        res
+    }
+
+    override def child: Expression = indexID
+
+    override protected def withNewChildInternal(newChild: Expression): Expression = copy(indexID = newChild)
+
+}
+
+object GridCenterAsWKB {
+
+    /** Entry to use in the function registry. */
+    def registryExpressionInfo(db: Option[String]): ExpressionInfo =
+        new ExpressionInfo(
+            classOf[GridCenterAsWKB].getCanonicalName,
+            db.orNull,
+            "grid_centeraswkb",
+            """
+              |    _FUNC_(indexID) - Returns the geometry representing the centroid of the index.
+            """.stripMargin,
+            "",
+            """
+              |    Examples:
+              |      > SELECT _FUNC_(a);
+              |        0001100100100.....001010 // WKB
+              |  """.stripMargin,
+            "",
+            "misc_funcs",
+            "1.0",
+            "",
+            "built-in"
+        )
+}

--- a/src/main/scala/com/databricks/labs/mosaic/functions/MosaicContext.scala
+++ b/src/main/scala/com/databricks/labs/mosaic/functions/MosaicContext.scala
@@ -657,6 +657,14 @@ class MosaicContext(indexSystem: IndexSystem, geometryAPI: GeometryAPI) extends 
             ColumnAdapter(IndexGeometry(indexID.expr, format.expr, indexSystem.name, geometryAPI.name))
         def grid_boundary(indexID: Column, format: String): Column =
             ColumnAdapter(IndexGeometry(indexID.expr, lit(format).expr, indexSystem.name, geometryAPI.name))
+        def grid_centeraswkb(indexID: Column): Column =
+            if (shouldUseDatabricksH3()) {
+                getProductMethod("h3_centeraswkb")
+                    .apply(indexID)
+                    .asInstanceOf[Column]
+            } else {
+                ColumnAdapter(GridCenterAsWKB(indexID.expr, indexSystem.name, getGeometryAPI.name))
+            }
 
         // Not specific to Mosaic
         def try_sql(inCol: Column): Column = ColumnAdapter(TrySql(inCol.expr))

--- a/src/test/scala/com/databricks/labs/mosaic/core/index/TestBNGIndexSystem.scala
+++ b/src/test/scala/com/databricks/labs/mosaic/core/index/TestBNGIndexSystem.scala
@@ -3,6 +3,7 @@ package com.databricks.labs.mosaic.core.index
 import org.apache.spark.unsafe.types.UTF8String
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
+import com.databricks.labs.mosaic.core.geometry.api.GeometryAPI.{ESRI, JTS}
 
 class TestBNGIndexSystem extends AnyFlatSpec {
 
@@ -155,6 +156,15 @@ class TestBNGIndexSystem extends AnyFlatSpec {
         noException should be thrownBy BNGIndexSystem.getResolution(UTF8String.fromString("100m"))
         BNGIndexSystem.getResolutionStr(4) shouldEqual "100m"
         BNGIndexSystem.getResolutionStr(-4) shouldEqual "500m"
+    }
+
+    "GridCenterAsWKB" should "generate the correct centroids for an index in all Geometry APIs." in {
+        val index = 1050138790
+        val centroid1 = BNGIndexSystem.GridCenterAsWKB(index, JTS)
+        val centroid2 = BNGIndexSystem.GridCenterAsWKB(index, ESRI)
+
+        centroid1.toWKT shouldBe BNGIndexSystem.indexToGeometry(index, JTS).getCentroid.toWKT
+        centroid2.toWKT shouldBe BNGIndexSystem.indexToGeometry(index, ESRI).getCentroid.toWKT
     }
 
 }

--- a/src/test/scala/com/databricks/labs/mosaic/core/index/TestH3IndexSystem.scala
+++ b/src/test/scala/com/databricks/labs/mosaic/core/index/TestH3IndexSystem.scala
@@ -1,6 +1,6 @@
 package com.databricks.labs.mosaic.core.index
 
-import com.databricks.labs.mosaic.core.geometry.api.GeometryAPI.JTS
+import com.databricks.labs.mosaic.core.geometry.api.GeometryAPI.{JTS, ESRI}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 
@@ -12,5 +12,64 @@ class TestH3IndexSystem extends AnyFlatSpec {
         noException shouldBe thrownBy { H3IndexSystem.getResolutionStr(10) }
         noException shouldBe thrownBy { H3IndexSystem.indexToGeometry(H3IndexSystem.format(indexRes), JTS) }
     }
+
+    "Point to Index" should "generate index ID for all valid resolutions." in {
+        val indexRes0 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 0)
+        val indexRes1 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 1)
+        val indexRes2 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 2)
+        val indexRes3 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 3)
+        val indexRes4 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 4)
+        val indexRes5 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 5)
+        val indexRes6 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 6)
+        val indexRes7 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 7)
+        val indexRes8 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 8)
+        val indexRes9 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 9)
+        val indexRes10 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 10)
+        val indexRes11 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 11)
+        val indexRes12 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 12)
+        val indexRes13 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 13)
+        val indexRes14 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 14)
+        val indexRes15 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 15)
+
+        indexRes0 shouldBe 576918149140578303L
+        indexRes1 shouldBe 581412952674926591L
+        indexRes2 shouldBe 585913253767413759L
+        indexRes3 shouldBe 590416509797400575L
+        indexRes4 shouldBe 594920100834836479L
+        indexRes5 shouldBe 599423697240981503L
+        indexRes6 shouldBe 603927296734134271L
+        indexRes7 shouldBe 608430896244064255L
+        indexRes8 shouldBe 612934495858851839L
+        indexRes9 shouldBe 617438095484387327L
+        indexRes10 shouldBe 621941695111593983L
+        indexRes11 shouldBe 626445294738935807L
+        indexRes12 shouldBe 630948894366305791L
+        indexRes13 shouldBe 635452493993676095L
+        indexRes14 shouldBe 639956093621046583L
+        indexRes15 shouldBe 644459693248417076L
+
+    }
+
+    "GridCenterAsWKB" should "generate index Centroid for valid Indexes for all geometries." in {
+        val indexRes0 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 0)
+        val indexRes9 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 9)
+        val indexRes15 = H3IndexSystem.pointToIndex(-0.075441, 51.505480, 15)
+
+        val centroidRes0 = H3IndexSystem.GridCenterAsWKB(indexRes0, JTS)
+        val centroidRes9 = H3IndexSystem.GridCenterAsWKB(indexRes9, ESRI)
+        val centroidRes15 = H3IndexSystem.GridCenterAsWKB(indexRes15, JTS)
+
+        val List(x, y) = centroidRes0.toInternal.boundaries(0)(0).coords
+        ((x * 1e6).round / 1e6) shouldBe -11.601626
+        ((y * 1e6).round / 1e6) shouldBe 52.675751
+
+        // Reduced the precision here to avoid rounding errors.
+        centroidRes0.toWKT should (include("POINT") and include("-11.60162") and include("52.67575"))
+        centroidRes9.toWKT should (include("POINT") and include("-0.07363") and include("51.50493"))
+        centroidRes15.toWKT should (include("POINT") and include("-0.07544") and include("51.50547"))
+
+    }
+
+
 
 }

--- a/src/test/scala/com/databricks/labs/mosaic/expressions/index/GridCenterAsWKBBehaviors.scala
+++ b/src/test/scala/com/databricks/labs/mosaic/expressions/index/GridCenterAsWKBBehaviors.scala
@@ -1,0 +1,34 @@
+package com.databricks.labs.mosaic.expressions.index
+
+import com.databricks.labs.mosaic.functions.MosaicContext
+import com.databricks.labs.mosaic.test.mocks.pointDf
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.SparkSession
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+trait GridCenterAsWKBBehaviors {
+    this: AnyFlatSpec =>
+
+    def GridCenterAsWKB(mosaicContext: => MosaicContext, spark: => SparkSession, resolution: Int): Unit = {
+        val mc = mosaicContext
+        import mc.functions._
+        mosaicContext.register(spark)
+
+        val points = pointDf(spark, mc)
+            .withColumn("ix", grid_pointascellid(col("geometry"), resolution))
+            .withColumn("ix_centroid", grid_centeraswkb(col("ix")))
+            .withColumn("centroid_wkt", st_asbinary(col("ix_centroid")))
+
+        points.createOrReplaceTempView("centroid_indexes")
+
+        val points2 = spark
+            .sql("""| select grid_centeraswkb(ix) AS ix_centroid
+                    | from centroid_indexes
+                    |""".stripMargin)
+            .collect()
+
+        points.select("ix_centroid").collect() shouldBe points2
+    }
+
+}

--- a/src/test/scala/com/databricks/labs/mosaic/functions/auxiliary/BadIndexSystem.scala
+++ b/src/test/scala/com/databricks/labs/mosaic/functions/auxiliary/BadIndexSystem.scala
@@ -32,4 +32,6 @@ object BadIndexSystem extends IndexSystem {
     override def indexToGeometry(index: String, geometryAPI: GeometryAPI): MosaicGeometry = throw new UnsupportedOperationException
 
     override def pointToIndex(lon: Double, lat: Double, resolution: Int): Long = throw new UnsupportedOperationException
+
+    override def GridCenterAsWKB(index: Long, geometryAPI: GeometryAPI): MosaicGeometry = throw new UnsupportedOperationException
 }

--- a/src/test/scala/com/databricks/labs/mosaic/test/package.scala
+++ b/src/test/scala/com/databricks/labs/mosaic/test/package.scala
@@ -359,6 +359,8 @@ package object test {
 
         override def getBufferRadius(geometry: MosaicGeometry, resolution: Int, geometryAPI: GeometryAPI): Double = ???
 
+        override def GridCenterAsWKB(index: Long, geometryAPI: GeometryAPI): MosaicGeometry = ???
+
     }
 
 }


### PR DESCRIPTION
Implemented a function that returns the centroid of an index: grid_tocenterwkb.
Available in SQL, Scala and Python. I believe R should happen automagically.

In H3 it uses the underlying h3.h3ToGeo function, and in BNG it is defined as [X,Y] + edge_distance / 2.