### PR TITLE
H3 Python - 3.7.0

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 python_requires = >=3.7.0
 install_requires =
     keplergl==0.3.2
-    h3==3.7.3
+    h3==3.7.0
     ipython==7.22.0
 
 [options.package_data]


### PR DESCRIPTION
python h3 - back to 3.7.0 to match POM