### PR TITLE
Fix the Ship-2-Ship solacc data download

### DIFF
--- a/docs/source/api/api.rst
+++ b/docs/source/api/api.rst
@@ -10,4 +10,3 @@ API Documentation
    spatial-indexing
    spatial-predicates
    spatial-aggregations
-   raster-functions

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@
    :width: 50%
    :alt: mosaic
    :align: left
-
+|
 .. image:: https://badge.fury.io/py/databricks-mosaic.svg
    :target: https://badge.fury.io/py/databricks-mosaic
    :alt: PyPI Version

--- a/docs/source/usage/usage.rst
+++ b/docs/source/usage/usage.rst
@@ -5,7 +5,6 @@ Usage
    :maxdepth: 2
 
    installation
-   install-gdal
    grid-indexes
    grid-indexes-bng
    quickstart

--- a/notebooks/examples/python/Ship2ShipTransfers/01. Data Prep.py
+++ b/notebooks/examples/python/Ship2ShipTransfers/01. Data Prep.py
@@ -89,7 +89,8 @@ display(AIS_df)
 # MAGIC %sh
 # MAGIC # we download data to dbfs:// mountpoint (/dbfs)
 # MAGIC cd /dbfs/tmp/ship2ship/
-# MAGIC wget -np -r -nH -L -q --cut-dirs=7 -O harbours.geojson "https://geo.dot.gov/mapping/rest/services/NTAD/Ports_Major/MapServer/0/query?outFields=*&where=1%3D1&f=geojson"
+# MAGIC # wget -np -r -nH -L -q --cut-dirs=7 -O harbours.geojson "https://geo.dot.gov/mapping/rest/services/NTAD/Ports_Major/MapServer/0/query?outFields=*&where=1%3D1&f=geojson"
+# MAGIC wget -np -r -nH -L -q --cut-dirs=7 -O harbours.geojson "https://geo.dot.gov/mapping/rest/services/NTAD/Strategic_Ports/MapServer/0/query?outFields=*&where=1%3D1&f=geojson"
 
 # COMMAND ----------
 


### PR DESCRIPTION
Update the URL for the NTAD port data to reflect its new location. The URL presently used is stale. 