### PR TITLE
fix issue 294

### DIFF
--- a/src/test/scala/com/databricks/labs/mosaic/core/geometry/multipolygon/TestMultiPolygonESRI.scala
+++ b/src/test/scala/com/databricks/labs/mosaic/core/geometry/multipolygon/TestMultiPolygonESRI.scala
@@ -38,6 +38,13 @@ class TestMultiPolygonESRI extends AnyFlatSpec {
         multiPolygon.equals(MosaicMultiPolygonESRI.fromInternal(multiPolygon.toInternal.serialize.asInstanceOf[InternalRow])) shouldBe true
     }
 
+    "MosaicMultiPolygonESRI" should "load holes correctly" in {
+         val multiPolygon = MosaicMultiPolygonESRI.fromWKT(
+          "MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)), ((3 4,6 3,5 5,3 4)))"
+        )
+        multiPolygon.equals(MosaicMultiPolygonESRI.fromInternal(multiPolygon.toInternal.serialize.asInstanceOf[InternalRow])) shouldBe true
+    }
+    
     "MosaicMultiPolygonESRI" should "be instantiable from a Seq of MosaicPolygonESRI" in {
         val multiPolygonReference = MosaicMultiPolygonESRI.fromWKT(
           "MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))"


### PR DESCRIPTION
Fixes #294, which is caused by incorrect order of paths being added to Pylygon in `com.databricks.labs.mosaic.core.geometry.multipolygon.MosaicMultiPolygonESRI.createPolygon`. Boundaries and holes need to be added in sequence (e.g. a boundary then its holes followed by a second boundary, etc), otherwise, OGCPolygon constructor will pick them up in the incorrect order.

Added a dedicated test