### PR TITLE
fix H3 geometry constructor

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,1 @@
+-Djts.overlay=ng

--- a/src/main/scala/com/databricks/labs/mosaic/core/index/H3IndexSystem.scala
+++ b/src/main/scala/com/databricks/labs/mosaic/core/index/H3IndexSystem.scala
@@ -250,33 +250,25 @@ object H3IndexSystem extends IndexSystem(LongType) with Serializable {
         else (lng, lat)
     }
 
-
     private def makeUnsafeGeometry(coordinates: mutable.Buffer[GeoCoord], geometryAPI: GeometryAPI): MosaicGeometry = {
         geometryAPI.geometry(
-            coordinates.map(p => geometryAPI.fromGeoCoord(Coordinates(p.lat, p.lng))),
-            POLYGON
+          coordinates.map(p => geometryAPI.fromGeoCoord(Coordinates(p.lat, p.lng))),
+          POLYGON
         )
     }
 
-    private def makeEastBBox(geometryAPI: GeometryAPI): MosaicGeometry = makeUnsafeGeometry(
-        mutable.Buffer(
-            new GeoCoord(-90, 0),
-            new GeoCoord(90, 0),
-            new GeoCoord(90, 180),
-            new GeoCoord(-90, 180),
-            new GeoCoord(-90, 0)),
-        geometryAPI: GeometryAPI)
+    private def makeEastBBox(geometryAPI: GeometryAPI): MosaicGeometry =
+        makeUnsafeGeometry(
+          mutable.Buffer(new GeoCoord(-90, 0), new GeoCoord(90, 0), new GeoCoord(90, 180), new GeoCoord(-90, 180), new GeoCoord(-90, 0)),
+          geometryAPI: GeometryAPI
+        )
 
-
-    private def makeShiftedWestBBox(geometryAPI: GeometryAPI): MosaicGeometry = makeUnsafeGeometry(
-        mutable.Buffer(
-            new GeoCoord(-90, 180),
-            new GeoCoord(90, 180),
-            new GeoCoord(90, 360),
-            new GeoCoord(-90, 360),
-            new GeoCoord(-90, 180)),
-        geometryAPI: GeometryAPI)
-
+    private def makeShiftedWestBBox(geometryAPI: GeometryAPI): MosaicGeometry =
+        makeUnsafeGeometry(
+          mutable
+              .Buffer(new GeoCoord(-90, 180), new GeoCoord(90, 180), new GeoCoord(90, 360), new GeoCoord(-90, 360), new GeoCoord(-90, 180)),
+          geometryAPI: GeometryAPI
+        )
 
     private def makePoleGeometry(coordinates: mutable.Buffer[GeoCoord], isNorthPole: Boolean, geometryAPI: GeometryAPI): MosaicGeometry = {
 
@@ -284,17 +276,16 @@ object H3IndexSystem extends IndexSystem(LongType) with Serializable {
 
         val coords = coordinates.map(geoCoord => shiftEast(geoCoord.lng, geoCoord.lat)).sortBy(_._1)
         val lineString = geometryAPI.geometry(
-            coords.map(p => geometryAPI.fromGeoCoord(Coordinates(p._2, p._1))),
-            LINESTRING
+          coords.map(p => geometryAPI.fromGeoCoord(Coordinates(p._2, p._1))),
+          LINESTRING
         )
 
         val westernLine = lineString.intersection(makeEastBBox(geometryAPI))
         val easternLine = lineString.intersection(makeShiftedWestBBox(geometryAPI)).mapXY(shiftWest)
 
         val vertices = westernLine.getShellPoints.head ++
-          Seq(geometryAPI.fromGeoCoord(Coordinates(lat, 180)),
-              geometryAPI.fromGeoCoord(Coordinates(lat, -180))) ++
-          easternLine.getShellPoints.head ++ Seq(westernLine.getShellPoints.head.head)
+            Seq(geometryAPI.fromGeoCoord(Coordinates(lat, 180)), geometryAPI.fromGeoCoord(Coordinates(lat, -180))) ++
+            easternLine.getShellPoints.head ++ Seq(westernLine.getShellPoints.head.head)
 
         geometryAPI.geometry(vertices, POLYGON)
 
@@ -309,8 +300,7 @@ object H3IndexSystem extends IndexSystem(LongType) with Serializable {
             val westGeom = shiftedGeometry.intersection(makeEastBBox(geometryAPI: GeometryAPI))
             val eastGeom = shiftedGeometry.intersection(makeShiftedWestBBox(geometryAPI: GeometryAPI)).mapXY(shiftWest)
             westGeom.union(eastGeom)
-        }
-        else {
+        } else {
             unsafeGeometry
         }
 

--- a/src/test/scala/com/databricks/labs/mosaic/core/index/H3IndexSystemTest.scala
+++ b/src/test/scala/com/databricks/labs/mosaic/core/index/H3IndexSystemTest.scala
@@ -1,15 +1,20 @@
 package com.databricks.labs.mosaic.core.index
 
-import com.databricks.labs.mosaic.core.geometry.api.{ESRI, JTS}
+import com.databricks.labs.mosaic.core.geometry.api.{ESRI, GeometryAPI, JTS}
 import com.databricks.labs.mosaic.core.geometry.{MosaicGeometryESRI, MosaicGeometryJTS}
+import com.databricks.labs.mosaic.core.index.H3IndexSystem.indexToGeometry
 import com.databricks.labs.mosaic.core.types.model.GeometryTypeEnum.{LINESTRING, MULTILINESTRING, MULTIPOINT, MULTIPOLYGON, POINT, POLYGON}
 import com.databricks.labs.mosaic.core.types.model.GeometryTypeEnum
+import com.uber.h3core.H3Core
 import org.apache.spark.sql.types.{BooleanType, LongType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
+import org.scalactic.Tolerance
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers._
 
-class H3IndexSystemTest extends AnyFunSuite {
+import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
+
+class H3IndexSystemTest extends AnyFunSuite with Tolerance {
 
     test("H3IndexSystem auxiliary methods") {
         val indexRes = H3IndexSystem.pointToIndex(10, 10, 10)
@@ -129,4 +134,23 @@ class H3IndexSystemTest extends AnyFunSuite {
         H3IndexSystem.coerceChipGeometry(geomsWKTs4.map(MosaicGeometryESRI.fromWKT)).isEmpty shouldBe true
     }
 
+    test("indexToGeometry should return valid and correct geometries") {
+        val h3: H3Core = H3Core.newInstance()
+
+        val esriGeomAPI: GeometryAPI = GeometryAPI("ESRI")
+        val jtsGeomAPI: GeometryAPI = GeometryAPI("JTS")
+        val apis = Seq(esriGeomAPI, jtsGeomAPI)
+
+        val baseCells = h3.getRes0Indexes.asScala.toList
+        val lvl1Cells = baseCells.flatMap(h3.h3ToChildren(_, 1).asScala)
+        val testCells = Seq(baseCells, lvl1Cells)
+
+        apis.foreach(api => {
+            testCells.foreach(cells => {
+                val geoms = cells.map(indexToGeometry(_, api))
+                geoms.foreach(geom => geom.isValid shouldBe true)
+                geoms.foldLeft(0.0)((acc, geom) => acc + geom.getArea) shouldBe ((180.0 * 360.0) +- 0.0001)
+            })
+        })
+    }
 }

--- a/src/test/scala/com/databricks/labs/mosaic/core/index/H3IndexSystemTest.scala
+++ b/src/test/scala/com/databricks/labs/mosaic/core/index/H3IndexSystemTest.scala
@@ -145,8 +145,17 @@ class H3IndexSystemTest extends AnyFunSuite with Tolerance {
         val lvl1Cells = baseCells.flatMap(h3.h3ToChildren(_, 1).asScala)
         val testCells = Seq(baseCells, lvl1Cells)
 
+        val baseCellsStr = baseCells.map(h3.h3ToString(_))
+        val lvl1CellsStr = lvl1Cells.map(h3.h3ToString(_))
+        val testCellsStr = Seq(baseCellsStr, lvl1CellsStr)
+
         apis.foreach(api => {
             testCells.foreach(cells => {
+                val geoms = cells.map(indexToGeometry(_, api))
+                geoms.foreach(geom => geom.isValid shouldBe true)
+                geoms.foldLeft(0.0)((acc, geom) => acc + geom.getArea) shouldBe ((180.0 * 360.0) +- 0.0001)
+            })
+            testCellsStr.foreach(cells => {
                 val geoms = cells.map(indexToGeometry(_, api))
                 geoms.foreach(geom => geom.isValid shouldBe true)
                 geoms.foldLeft(0.0)((acc, geom) => acc + geom.getArea) shouldBe ((180.0 * 360.0) +- 0.0001)


### PR DESCRIPTION
The coordinate buffer returned from the H3 API does not indicate how the geometry needs to be constructed. The current method returns invalid geometries for cells that cover the poles and/or the anti-meridian, as reported here #371. 

This PR makes sure that
- H3 geometries covering the poles are valid and fill out the entire pole region
- H3 geometries crossing the anti-meridian are valid and are broken down into a multi-polygon

The implementation should work for both ESRI and JTS Geometry API.

Signed-off-by: Thomas Maschler <thomas.maschler@cervest.earth>