### PR TITLE
Fix for issue 383

### DIFF
--- a/src/test/scala/com/databricks/labs/mosaic/expressions/index/PointIndexTest.scala
+++ b/src/test/scala/com/databricks/labs/mosaic/expressions/index/PointIndexTest.scala
@@ -8,5 +8,6 @@ class PointIndexTest extends MosaicSpatialQueryTest with SharedSparkSession with
     testAllNoCodegen("PointIndex behavior int resolution") { behaviorInt }
     testAllNoCodegen("PointIndex behavior string resolution") { behaviorString }
     testAllNoCodegen("PointIndex auxiliary methods") { auxiliaryMethods }
+    testAllNoCodegen("PointIndex through saveAsTable") { issue_383 }
 
 }


### PR DESCRIPTION
Fixes #383

Using grid_pointascellid on a geometry in Dataframe loaded from a table created from another dataframe containing the geometry using saveAsTable throws an exception because the data type is not recognized as InternalGeometryType but StructType.
This PR fixes the issue, however I suspect similar issues may exist in other places and probably a better way to address those is to implement a similar fix in the GeomentyAPI.geometry.
To keep the blast radius small, I implemented it only in PointIndexGeom, but I also have a ready implementation for GeometryAPI if needed.