### PR TITLE
removed gdal python package as dependency in our python package

### DIFF
--- a/.github/actions/python_build/action.yml
+++ b/.github/actions/python_build/action.yml
@@ -11,7 +11,7 @@ runs:
       shell: bash
       run: |
         cd python
-        pip install build wheel pyspark==${{ matrix.spark }} numpy==${{ matrix.numpy }}
+        pip install build wheel pyspark==${{ matrix.spark }} numpy==${{ matrix.numpy }} gdal==${{ matrix.gdal }}
         pip install .
     - name: Test and build python package
       shell: bash

--- a/.github/actions/python_build/action.yml
+++ b/.github/actions/python_build/action.yml
@@ -11,7 +11,8 @@ runs:
       shell: bash
       run: |
         cd python
-        pip install build wheel pyspark==${{ matrix.spark }} numpy==${{ matrix.numpy }} gdal==${{ matrix.gdal }}
+        pip install build wheel pyspark==${{ matrix.spark }} numpy==${{ matrix.numpy }}
+        pip install gdal==${{ matrix.gdal }}
         pip install .
     - name: Test and build python package
       shell: bash

--- a/.github/actions/scala_build/action.yml
+++ b/.github/actions/scala_build/action.yml
@@ -21,7 +21,6 @@ runs:
           run : |
             sudo apt-get update && sudo apt-get install -y unixodbc libcurl3-gnutls libsnappy-dev libopenjp2-7 
             pip install databricks-mosaic-gdal==${{ matrix.gdal }}
-            ls /opt/hostedtoolcache/Python/${{ matrix.python }}/x64/lib/python3.9/site-packages/databricks-mosaic-gdal/resources/gdal-${{ matrix.gdal }}-filetree.tar.xz
             sudo tar -xf /opt/hostedtoolcache/Python/${{ matrix.python }}/x64/lib/python3.9/site-packages/databricks-mosaic-gdal/resources/gdal-${{ matrix.gdal }}-filetree.tar.xz -C /
             sudo tar -xhf /opt/hostedtoolcache/Python/${{ matrix.python }}/x64/lib/python3.9/site-packages/databricks-mosaic-gdal/resources/gdal-${{ matrix.gdal }}-symlinks.tar.xz -C /
         - name: Test and build the scala JAR - skip tests is false

--- a/.github/actions/scala_build/action.yml
+++ b/.github/actions/scala_build/action.yml
@@ -21,6 +21,7 @@ runs:
           run : |
             sudo apt-get update && sudo apt-get install -y unixodbc libcurl3-gnutls libsnappy-dev libopenjp2-7 
             pip install databricks-mosaic-gdal==${{ matrix.gdal }}
+            ls /opt/hostedtoolcache/Python/${{ matrix.python }}/x64/lib/python3.9/site-packages/databricks-mosaic-gdal/resources/gdal-${{ matrix.gdal }}-filetree.tar.xz
             sudo tar -xf /opt/hostedtoolcache/Python/${{ matrix.python }}/x64/lib/python3.9/site-packages/databricks-mosaic-gdal/resources/gdal-${{ matrix.gdal }}-filetree.tar.xz -C /
             sudo tar -xhf /opt/hostedtoolcache/Python/${{ matrix.python }}/x64/lib/python3.9/site-packages/databricks-mosaic-gdal/resources/gdal-${{ matrix.gdal }}-symlinks.tar.xz -C /
         - name: Test and build the scala JAR - skip tests is false

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -24,7 +24,6 @@ setup_requires =
 install_requires =
     keplergl==0.3.2
     h3==3.7.3
-    gdal[numpy]==3.4.3
 
 [options.package_data]
 mosaic =

--- a/python/test/test_raster_functions.py
+++ b/python/test/test_raster_functions.py
@@ -1,7 +1,3 @@
-import logging
-import random
-import unittest
-
 from pyspark.sql.functions import abs, col, first, lit, sqrt, array
 
 from .context import api


### PR DESCRIPTION
Our python package setup currently fails if gdal natives don't already exist in the target environment. This PR addresses the issue by removing the dependency. Users are assumed to have run the init script before attempting to use any functions such as `RST_NDVI` which call out to python to perform map algebra.