### PR TITLE
fix docstring so that edgeratio=0 is not boundingbox

### DIFF
--- a/python/mosaic/api/functions.py
+++ b/python/mosaic/api/functions.py
@@ -159,13 +159,13 @@ def st_concavehull(geom: ColumnOrName, concavity: ColumnOrName, has_holes: Any =
     """
     Compute the concave hull of a geometry or multi-geometry object.
     It uses lengthRatio and
-    allowHoles to determine the concave hull. lengthRatio is the ratio of the
-    length of the concave hull to the length of the convex hull. If set to 1,
-    this is the same as the convex hull. If set to 0, this is the same as the
-    bounding box. AllowHoles is a boolean that determines whether the concave
-    hull can have holes. If set to true, the concave hull can have holes. If set
-    to false, the concave hull will not have holes. (For PostGIS, the default is
-    false.)
+    allowHoles to determine the concave hull. lengthRatio is the fraction of the
+    difference between the longest and shortest edge lengths in the Delaunay
+    Triangulation. If set to 1, this is the same as the convex hull. If set to
+    0, it produces produces maximum concaveness. AllowHoles is a boolean that
+    determines whether the concave hull can have holes. If set to true, the
+    concave hull can have holes. If set to false, the concave hull will not have
+    holes. (For PostGIS, the default is false.)
 
     Parameters
     ----------

--- a/src/main/scala/com/databricks/labs/mosaic/expressions/geometry/ST_ConcaveHull.scala
+++ b/src/main/scala/com/databricks/labs/mosaic/expressions/geometry/ST_ConcaveHull.scala
@@ -12,13 +12,13 @@ import org.apache.spark.sql.types.DataType
 
 /**
   * Returns the concave hull for a given geometry. It uses lengthRatio and
-  * allowHoles to determine the concave hull. lengthRatio is the ratio of the
-  * length of the concave hull to the length of the convex hull. If set to 1,
-  * this is the same as the convex hull. If set to 0, this is the same as the
-  * bounding box. AllowHoles is a boolean that determines whether the concave
-  * hull can have holes. If set to true, the concave hull can have holes. If set
-  * to false, the concave hull will not have holes. (For PostGIS, the default is
-  * false.)
+  * allowHoles to determine the concave hull. lengthRatio is the fraction of the
+  * difference between the longest and shortest edge lengths in the Delaunay
+  * Triangulation. If set to 1, this is the same as the convex hull. If set to
+  * 0, it produces produces maximum concaveness. AllowHoles is a boolean that
+  * determines whether the concave hull can have holes. If set to true, the
+  * concave hull can have holes. If set to false, the concave hull will not have
+  * holes. (For PostGIS, the default is false.)
   * @param inputGeom
   *   The input geometry.
   * @param expressionConfig


### PR DESCRIPTION
(the branch is misnamed sorry, this is about the concavehull, not convexhull)

If I understand correctly, `ST_Concavehull` with `edgeRatio=0` does not produce the bounding box, but something that could be described like "vacuum-wrapping" the object. The more precise but more boring description of "maximum concaveness", from the [formal definition](https://locationtech.github.io/jts/javadoc/index.html?org/locationtech/jts/algorithm/hull/ConcaveHull.html) of JTS.
(In the current tests, the edgeRatio=0.01 does not produce a rectangular, coordinate-aligned bounding box either.)

Related, the ratio itself is not between the convex and concave hull but some fancier ratio related to the Delaunay triangulation.

I suggest for both to take over, the wording from JTS.