### PR TITLE
Add EoS banner to all documentation pages

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,6 +47,20 @@ templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', ".env"]
 source_suffix = [".rst", ".md"]
 
+rst_prolog = """
+.. important::
+
+   **Mosaic end of support** — DBLabs Mosaic reaches **end of support (EoS) with
+   Databricks Runtime 13.3 in August 2026**. We encourage existing and new users to
+   adopt the successor project
+   `Databricks Labs GeoBrix <https://github.com/databrickslabs/geobrix>`_ — a
+   high-performance spatial processing library for Databricks that continues and
+   modernizes Mosaic's capabilities (Raster, Grid, Vector), works with DBR 17.1+ and
+   product spatial features, and is built exclusively for the Databricks Runtime.
+   **Docs:** `databrickslabs.github.io/geobrix <https://databrickslabs.github.io/geobrix/>`_
+   · **Releases:** `github.com/databrickslabs/geobrix/releases <https://github.com/databrickslabs/geobrix/releases>`_
+"""
+
 pygments_style = 'sphinx'
 nbsphinx_execute = 'never'
 napoleon_use_admonition_for_notes = True


### PR DESCRIPTION
## Summary
- Adds an end-of-support notice to every Sphinx documentation page via `rst_prolog` in `docs/source/conf.py`
- Directs users to the successor project [Databricks Labs GeoBrix](https://github.com/databrickslabs/geobrix)
- No individual RST files were modified — the banner is injected automatically by Sphinx

## Test plan
- [ ] Build docs locally (`cd docs && make html`) and verify the banner appears at the top of every page
- [ ] Confirm links to GeoBrix docs and releases are correct and clickable

This pull request was AI-assisted by Isaac.